### PR TITLE
fix: make onefetch detection truly optional (#3)

### DIFF
--- a/xontrib/gitinfo.xsh
+++ b/xontrib/gitinfo.xsh
@@ -1,10 +1,11 @@
 import os
+import shutil
 
 __version__ = '0.1.0'
 __all__ = ()
 
-ONEFETCH = $(which onefetch)
-GIT = $(which git)
+ONEFETCH = shutil.which('onefetch')
+GIT = shutil.which('git')
 
 
 def __gitinfo_show_git_info():


### PR DESCRIPTION
## Summary

- Fixes #3 — the xontrib fails to load when `onefetch` is not installed, even though the README documents it as optional.
- Replaces `$(which onefetch)` / `$(which git)` with `shutil.which(...)` so a missing executable yields `None` instead of raising `subprocess.CalledProcessError` at import time.

## Root cause

```xsh
ONEFETCH = $(which onefetch)
GIT = $(which git)
```

When `onefetch` is absent from `$PATH`, `which onefetch` exits non-zero. In newer xonsh versions the captured-stdout helper raises `subprocess.CalledProcessError`, which propagates out of the module body and aborts `xontribs_load` — so the entire xontrib (including the `git`-only fallback) never loads.

## Fix

`shutil.which()` returns the resolved path or `None`. The existing `if ONEFETCH: ... elif GIT:` truthiness checks keep working, and there is no subprocess at import time anymore.